### PR TITLE
Release 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A digital passport. Verified once, usable everywhere.",
   "keywords": [
     "VC",


### PR DESCRIPTION
Bump to 0.1.3.

Changes since 0.1.2:
- KB JWT signature verification (#8)
- PAR request body fix (#8)
- CLAUDE.md release-flow cleanup (#8)

Merging this PR sets `package.json` to 0.1.3 on `main`. The actual npm publish is triggered after merge by creating a GitHub Release `v0.1.3` against the merged commit SHA.