### PR TITLE
[WALLET-46] Export ProofCredentialV1 and verify aud

### DIFF
--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -14,6 +14,8 @@ export type {
 
 export { TX_DATA_TYPE, transactionData } from "./transaction_data.ts";
 
+export { ProofCredentialV1 } from "./proof_credentials.ts";
+
 export {
   init,
   getAuthorizationRequestURL,

--- a/src/presentation/node_client.ts
+++ b/src/presentation/node_client.ts
@@ -15,11 +15,13 @@ import { VCPresentationClient } from "./base_client.ts";
 export type VerifyParams = {
   encodedSDJWT: string;
   nonce?: string;
+  aud?: string;
 };
 
 export type VerifyVPTokenParams = {
   encodedVPToken: string;
   nonce?: string;
+  aud?: string;
 };
 
 const VERIFIERS = { ES256, ES384, ES512 } as const;
@@ -57,6 +59,7 @@ export class NodeVCPresentationClient extends VCPresentationClient {
   public async verify({
     encodedSDJWT,
     nonce,
+    aud,
   }: VerifyParams): Promise<ProofCredential> {
     const decoded = await new SDJwtVcInstance({ hasher }).decode(encodedSDJWT);
     const alg = decoded.jwt?.header?.["alg"];
@@ -78,7 +81,12 @@ export class NodeVCPresentationClient extends VCPresentationClient {
       if (!isSupportedAlg(kbAlg)) {
         throw `Unsupported or missing KB JWT alg: ${kbAlg}`;
       }
+      if (aud !== undefined && decoded.kbJwt.payload?.aud !== aud) {
+        throw `KB JWT aud ${decoded.kbJwt.payload?.aud} does not match expected aud ${aud}`;
+      }
       kbVerifier = kbVerifierFor(kbAlg);
+    } else if (aud !== undefined) {
+      throw "aud was supplied for verification but the SD-JWT-VC contains no KB JWT";
     }
 
     const chain = x5c.map(
@@ -107,6 +115,7 @@ export class NodeVCPresentationClient extends VCPresentationClient {
   public async verifyVPToken({
     encodedVPToken,
     nonce,
+    aud,
   }: VerifyVPTokenParams): Promise<VPToken> {
     const records = JSON.parse(base64urlDecode(encodedVPToken)) as Record<
       string,
@@ -121,6 +130,7 @@ export class NodeVCPresentationClient extends VCPresentationClient {
         const credential = await this.verify({
           encodedSDJWT,
           ...(nonce !== undefined && { nonce }),
+          ...(aud !== undefined && { aud }),
         });
         vpToken[credentialId].push(credential);
       }


### PR DESCRIPTION
## Summary

- Export the `ProofCredentialV1` class from the Node entry (`src/index.node.ts`) so callers can narrow a `ProofCredential` via `instanceof ProofCredentialV1` and use its accessors (`givenName()`, `dateOfBirth()`, `isOver18()`, etc.). `ProofCredential` is already re-exported via `export type * from "./types.ts"`. Kept off the browser entry since `verify`/`verifyVPToken` are Node-only.
- Add an optional `aud` parameter to `verify` and `verifyVPToken`. When supplied:
  - With a KB JWT present, it asserts `kbJwt.payload.aud === aud` and throws on mismatch.
  - With no KB JWT present, it throws — consistent with how a present KB JWT already requires a `nonce`.
  - `aud` is threaded through `verifyVPToken` → `verify`.

## Testing

- `yarn check-all` passes (format, lint, typecheck, publint).
- Browser-graph grep after `yarn build` is clean (no `@sd-jwt`/`@owf`/`node:` leaks).
- This repo has no automated test suite; the quality gate is `yarn check-all`.

Jira: https://notarize.atlassian.net/browse/WALLET-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)