### PR TITLE
Release 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A digital passport. Verified once, usable everywhere.",
   "keywords": [
     "VC",


### PR DESCRIPTION
Version bump to 0.1.4.

Includes #10 — export `ProofCredentialV1` and add optional `aud` verification to `verify`/`verifyVPToken`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)