### PR TITLE
Release 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "A digital passport. Verified once, usable everywhere.",
   "keywords": [
     "VC",


### PR DESCRIPTION
Release 0.2.0.

Bumps `package.json` from 0.1.4 → 0.2.0 (minor, per semver 0.x for a breaking change).

## What's in this release (since v0.1.4)

- **[WALLET-63] Remove PAR from browser distribution (#13)** — breaking:
  - PAR and `client_secret` handling are now Node-only; the browser distribution cannot make pushed authorization requests.
  - Right-sized `init()` params per export (`BrowserInitParams` / `NodeInitParams`).
  - New named `TrustRoot` (`"development" | "production"`); `verify`/`verifyVPToken` require it explicitly.
  - camelCase consumer-authored params; `ProofCredentialV1` exposes property accessors.
- **Bump the npm-minor-patch group with 3 updates (#12)**.

## Note

After this merges, the GitHub Release `v0.2.0` still needs to be created against the merged commit to trigger `publish.yml`. That step is held for explicit confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)