### PR TITLE
[WALLET-89] Add getDCAPIAuthorizationRequest and default DCQL query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Browser-runtime files (reachable from `src/index.browser.ts`):
 - `src/vc_presentation.browser.ts`
 - `src/presentation/base_client.ts`
 - `src/transaction_data.ts`
+- `src/dcql.ts`
+- `src/constants.ts`
 - `src/types.ts` (type-only, erased at emit)
 
 Everything else under `src/` is Node-side. Verify after build:
@@ -26,7 +28,8 @@ Everything else under `src/` is Node-side. Verify after build:
 ```bash
 grep -lE '(jose|@sd-jwt|@owf|node:)' \
   dist/index.browser.js dist/vc_presentation.browser.js \
-  dist/presentation/base_client.js dist/transaction_data.js dist/types.js
+  dist/presentation/base_client.js dist/transaction_data.js \
+  dist/dcql.js dist/constants.js dist/types.js
 # Must match nothing.
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+import type { CredentialID } from "./types.ts";
+
+export const DEFAULT_CREDENTIAL_ID: CredentialID = "proof_id_default";
+
+export const PROOF_CREDENTIAL_V1_VCT =
+  "https://credentials.notarize.com/ProofCredentialV1";

--- a/src/dcql.ts
+++ b/src/dcql.ts
@@ -1,0 +1,26 @@
+import type { Format } from "./types.ts";
+import { DEFAULT_CREDENTIAL_ID, PROOF_CREDENTIAL_V1_VCT } from "./constants.ts";
+
+export type DCQLCredentialQueryMeta = {
+  vct_values: string[];
+};
+
+export type DCQLCredentialQuery = {
+  id: string;
+  format: Format;
+  meta: DCQLCredentialQueryMeta;
+};
+
+export type DCQLQuery = {
+  credentials: DCQLCredentialQuery[];
+};
+
+export const DCQL_QUERY_BASIC: DCQLQuery = {
+  credentials: [
+    {
+      id: DEFAULT_CREDENTIAL_ID,
+      format: "dc+sd-jwt",
+      meta: { vct_values: [PROOF_CREDENTIAL_V1_VCT] },
+    },
+  ],
+};

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -15,8 +15,22 @@ export type {
 export { TX_DATA_TYPE, transactionData } from "./transaction_data.ts";
 
 export type {
+  DCQLQuery,
+  DCQLCredentialQuery,
+  DCQLCredentialQueryMeta,
+} from "./dcql.ts";
+
+export { DCQL_QUERY_BASIC } from "./dcql.ts";
+
+export type {
   BrowserInitParams,
   AuthorizationRequestParams,
+  DCAPIAuthorizationRequestParams,
+  AuthorizationRequest,
 } from "./presentation/base_client.ts";
 
-export { init, getAuthorizationRequestURL } from "./vc_presentation.browser.ts";
+export {
+  init,
+  getAuthorizationRequestURL,
+  getDCAPIAuthorizationRequest,
+} from "./vc_presentation.browser.ts";

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -14,9 +14,21 @@ export type {
 
 export { TX_DATA_TYPE, transactionData } from "./transaction_data.ts";
 
+export type {
+  DCQLQuery,
+  DCQLCredentialQuery,
+  DCQLCredentialQueryMeta,
+} from "./dcql.ts";
+
+export { DCQL_QUERY_BASIC } from "./dcql.ts";
+
 export { ProofCredentialV1 } from "./proof_credentials.ts";
 
-export type { AuthorizationRequestParams } from "./presentation/base_client.ts";
+export type {
+  AuthorizationRequestParams,
+  DCAPIAuthorizationRequestParams,
+  AuthorizationRequest,
+} from "./presentation/base_client.ts";
 export type {
   NodeInitParams,
   VerifyParams,
@@ -26,6 +38,7 @@ export type {
 export {
   init,
   getAuthorizationRequestURL,
+  getDCAPIAuthorizationRequest,
   verify,
   verifyVPToken,
 } from "./vc_presentation.node.ts";

--- a/src/presentation/base_client.ts
+++ b/src/presentation/base_client.ts
@@ -8,6 +8,7 @@ import {
   encodeTransactionData,
   type TransactionData,
 } from "../transaction_data.ts";
+import type { DCQLQuery } from "../dcql.ts";
 
 export type BrowserInitParams = {
   environment: Environment;
@@ -16,12 +17,31 @@ export type BrowserInitParams = {
   responseMode?: ResponseMode;
 };
 
-export type AuthorizationRequestParams = {
-  scope: Scope;
+type BaseAuthorizationRequestParams = {
   nonce: string;
   state?: string;
   loginHint?: string;
   transactionData?: TransactionData | string;
+};
+
+export type AuthorizationRequestParams = BaseAuthorizationRequestParams &
+  (
+    | { scope: Scope; dcqlQuery?: never }
+    | { dcqlQuery: DCQLQuery; scope?: never }
+  );
+
+export type DCAPIAuthorizationRequestParams = {
+  dcqlQuery: DCQLQuery;
+  nonce: string;
+  transactionData?: TransactionData | string;
+};
+
+export type AuthorizationRequest = {
+  response_type: ResponseType;
+  response_mode: "dc_api";
+  nonce: string;
+  dcql_query: DCQLQuery;
+  transaction_data?: string[];
 };
 
 export class VCPresentationClient {
@@ -57,6 +77,28 @@ export class VCPresentationClient {
   ): Promise<string> {
     this.requireRequestConfig();
     return this.buildAuthorizeURL(params);
+  }
+
+  // Builds an unsigned DC API request (`response_mode: "dc_api"`). DC API
+  // requests will eventually be signed (`response_mode: "dc_api.jwt"`).
+  public getDCAPIAuthorizationRequest({
+    dcqlQuery,
+    nonce,
+    transactionData,
+  }: DCAPIAuthorizationRequestParams): AuthorizationRequest {
+    const encodedTransactionData =
+      typeof transactionData === "object"
+        ? encodeTransactionData(transactionData)
+        : transactionData;
+    return {
+      response_type: this.responseType,
+      response_mode: "dc_api",
+      nonce,
+      dcql_query: dcqlQuery,
+      ...(encodedTransactionData !== undefined && {
+        transaction_data: [encodedTransactionData],
+      }),
+    };
   }
 
   protected requireRequestConfig(): void {
@@ -96,18 +138,23 @@ export class VCPresentationClient {
 
   protected buildParameters({
     scope,
+    dcqlQuery,
     nonce,
     state,
     loginHint,
     transactionData,
   }: AuthorizationRequestParams): URLSearchParams {
+    if ((scope === undefined) === (dcqlQuery === undefined)) {
+      throw "authorization request requires exactly one of `scope` or `dcqlQuery`";
+    }
     const encodedTransactionData =
       typeof transactionData === "object"
         ? encodeTransactionData(transactionData)
         : transactionData;
     return new URLSearchParams({
       ...this.defaultAuthorizationRequestParameters(),
-      scope,
+      ...(scope !== undefined && { scope }),
+      ...(dcqlQuery !== undefined && { dcql_query: JSON.stringify(dcqlQuery) }),
       nonce,
       ...(state !== undefined && { state }),
       ...(loginHint !== undefined && { login_hint: loginHint }),

--- a/src/proof_credential_factory.ts
+++ b/src/proof_credential_factory.ts
@@ -4,6 +4,7 @@ import {
   ProofCredentialV1,
 } from "./proof_credentials.ts";
 import { hasher } from "@owf/crypto";
+import { PROOF_CREDENTIAL_V1_VCT } from "./constants.ts";
 
 export const getProofCredential = async (
   sdjwt: SDJwt,
@@ -11,7 +12,7 @@ export const getProofCredential = async (
   const claims = (await sdjwt.getClaims(hasher)) as Record<string, unknown>;
   const vct = claims["vct"];
 
-  if (vct === "https://credentials.notarize.com/ProofCredentialV1") {
+  if (vct === PROOF_CREDENTIAL_V1_VCT) {
     const ages =
       claims["age_equal_or_over"] !== undefined
         ? (claims["age_equal_or_over"] as Record<string, boolean>)

--- a/src/transaction_data.ts
+++ b/src/transaction_data.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CREDENTIAL_ID } from "./constants.ts";
+
 export const TX_DATA_TYPE = {
   WIRE_INSTRUCTIONS:
     "urn:proof:params:vc:transaction-data:wire-instructions:v1",
@@ -6,7 +8,7 @@ export const TX_DATA_TYPE = {
   SESSION_DATA: "urn:proof:params:vc:transaction-data:session-data",
 } as const;
 
-const CREDENTIAL_IDS = ["proof_id_default"] as const;
+const CREDENTIAL_IDS = [DEFAULT_CREDENTIAL_ID] as const;
 
 export type WireInstructionsPayload = {
   recipient: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import type { CredentialID } from "./types.ts";
+import { DEFAULT_CREDENTIAL_ID } from "./constants.ts";
 
-const CREDENTIAL_IDS: CredentialID[] = ["proof_id_default"];
+const CREDENTIAL_IDS: CredentialID[] = [DEFAULT_CREDENTIAL_ID];
 
 export const credentialIdAsType = (s: string): CredentialID => {
   for (const credentialId of CREDENTIAL_IDS) {

--- a/src/vc_presentation.browser.ts
+++ b/src/vc_presentation.browser.ts
@@ -2,6 +2,8 @@ import {
   VCPresentationClient,
   type BrowserInitParams,
   type AuthorizationRequestParams,
+  type DCAPIAuthorizationRequestParams,
+  type AuthorizationRequest,
 } from "./presentation/base_client.ts";
 
 let instance: VCPresentationClient | null = null;
@@ -18,4 +20,12 @@ export async function getAuthorizationRequestURL(
   if (!instance)
     throw "VCPresentationClient not initialized — call init() first (browser)";
   return instance.getAuthorizationRequestURL(params);
+}
+
+export function getDCAPIAuthorizationRequest(
+  params: DCAPIAuthorizationRequestParams,
+): AuthorizationRequest {
+  if (!instance)
+    throw "VCPresentationClient not initialized — call init() first (browser)";
+  return instance.getDCAPIAuthorizationRequest(params);
 }

--- a/src/vc_presentation.node.ts
+++ b/src/vc_presentation.node.ts
@@ -1,4 +1,8 @@
-import type { AuthorizationRequestParams } from "./presentation/base_client.ts";
+import type {
+  AuthorizationRequestParams,
+  DCAPIAuthorizationRequestParams,
+  AuthorizationRequest,
+} from "./presentation/base_client.ts";
 import {
   NodeVCPresentationClient,
   type NodeInitParams,
@@ -21,6 +25,14 @@ export async function getAuthorizationRequestURL(
   if (!instance)
     throw "NodeVCPresentationClient not initialized — call init() first (node)";
   return instance.getAuthorizationRequestURL(params);
+}
+
+export function getDCAPIAuthorizationRequest(
+  params: DCAPIAuthorizationRequestParams,
+): AuthorizationRequest {
+  if (!instance)
+    throw "NodeVCPresentationClient not initialized — call init() first (node)";
+  return instance.getDCAPIAuthorizationRequest(params);
 }
 
 export async function verify(params: VerifyParams): Promise<ProofCredential> {


### PR DESCRIPTION
Adds `getDCAPIAuthorizationRequest` (unsigned W3C Digital Credentials API request object) and a default `DCQL_QUERY_BASIC`, with `scope`/`dcqlQuery` now mutually exclusive on the existing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)