### PR TITLE
Release 0.3.1

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@owf/crypto": "^0.3.1",
     "@owf/identity-common": "^0.3.1",
-    "@proof.com/proof-vc-common": "^0.3.0",
+    "@proof.com/proof-vc-common": "0.3.1",
     "@sd-jwt/core": "^0.20.0",
     "@sd-jwt/sd-jwt-vc": "^0.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,7 +203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@proof.com/proof-vc-common@npm:^0.3.0, @proof.com/proof-vc-common@workspace:packages/common":
+"@proof.com/proof-vc-common@npm:0.3.1, @proof.com/proof-vc-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@proof.com/proof-vc-common@workspace:packages/common"
   dependencies:
@@ -218,7 +218,7 @@ __metadata:
   dependencies:
     "@owf/crypto": "npm:^0.3.1"
     "@owf/identity-common": "npm:^0.3.1"
-    "@proof.com/proof-vc-common": "npm:^0.3.0"
+    "@proof.com/proof-vc-common": "npm:0.3.1"
     "@sd-jwt/core": "npm:^0.20.0"
     "@sd-jwt/sd-jwt-vc": "npm:^0.20.0"
     publint: "npm:^0.3.21"


### PR DESCRIPTION
Patch release bumping both packages to `0.3.1`.

Everything since the `0.3.0` release is Dependabot dependency bumps:
- #27 Bump brace-expansion 5.0.6 → 5.0.7
- #26 npm-minor-patch group (2 updates)
- #24 npm-minor-patch group (7 updates)

`packages/server` dependency on `@proof.com/proof-vc-common` pinned to exact `0.3.1`; `yarn.lock` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)