### PR TITLE
Release 0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Prompt before publishing (Hard Rule 2).
 1. Bump on a branch (the tag is created by `gh release create` in step 4):
    ```bash
    git switch -c release-X.Y.Z origin/main
-   npm version X.Y.Z --workspaces --no-git-tag-version --no-package-lock
+   npm version X.Y.Z --workspaces --include-workspace-root --no-git-tag-version --no-package-lock
    npm pkg set "dependencies[@proof.com/proof-vc-common]=X.Y.Z" -w packages/server --no-package-lock
    yarn install --no-immutable   # refresh yarn.lock for the bumped versions/range
    git commit -am "Release X.Y.Z"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-vc-workspace",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Jeremie Charrier <jeremie.charrier@proof.com>",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-server",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@owf/crypto": "^0.3.2",
     "@owf/identity-common": "^0.3.2",
-    "@proof.com/proof-vc-common": "0.3.1",
+    "@proof.com/proof-vc-common": "0.4.0",
     "@sd-jwt/core": "^0.20.0",
     "@sd-jwt/sd-jwt-vc": "^0.20.0",
     "jose": "^6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,7 +203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@proof.com/proof-vc-common@npm:0.3.1, @proof.com/proof-vc-common@workspace:packages/common":
+"@proof.com/proof-vc-common@npm:0.4.0, @proof.com/proof-vc-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@proof.com/proof-vc-common@workspace:packages/common"
   dependencies:
@@ -218,7 +218,7 @@ __metadata:
   dependencies:
     "@owf/crypto": "npm:^0.3.2"
     "@owf/identity-common": "npm:^0.3.2"
-    "@proof.com/proof-vc-common": "npm:0.3.1"
+    "@proof.com/proof-vc-common": "npm:0.4.0"
     "@sd-jwt/core": "npm:^0.20.0"
     "@sd-jwt/sd-jwt-vc": "npm:^0.20.0"
     jose: "npm:^6.2.3"


### PR DESCRIPTION
Bumps both packages to **0.4.0** (lockstep) and pins server's `@proof.com/proof-vc-common` dependency to `0.4.0`.

## Included since 0.3.1
- JAR support (RFC 9101): `authorizationUrl` by value, `signedAuthorizationRequest` + `jarByReferenceAuthorizationUrl` by reference, `signedDcApiRequest`
- Pushed Authorization Requests (PAR)
- Transaction data
- AS metadata resolved from the `/presentation` well-known endpoint

## Release steps
- [x] `npm version 0.4.0 --workspaces`
- [x] Pin server → common `0.4.0`
- [x] `yarn install --no-immutable` (refreshed `yarn.lock`)
- [x] `yarn check-all` + `yarn test` green
- [ ] Merge, then create Release `v0.4.0` against the merged SHA to trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)