### PR TITLE
[WALLET-184] Add response_uri to DC API request

### DIFF
--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -31,6 +31,7 @@ export type ServerAuthorizationRequestParams = AuthorizationRequestParams & {
 export type DCAPIAuthorizationRequestParams = {
   dcqlQuery: DCQLQuery;
   nonce: string;
+  expectedOrigins: [string, ...string[]];
   transactionData?: TransactionData | string;
 };
 
@@ -38,8 +39,10 @@ export type DCAPIAuthorizationRequest = {
   client_id: string;
   response_type: typeof RESPONSE_TYPE;
   response_mode: "dc_api";
+  response_uri: string;
   nonce: string;
   dcql_query: DCQLQuery;
+  expected_origins: [string, ...string[]];
   transaction_data?: string[];
 };
 
@@ -145,18 +148,24 @@ export function createClient(config: ServerClientConfig): ServerVCClient {
       return signedRequest(params);
     },
 
-    signedDcApiRequest({
+    async signedDcApiRequest({
       dcqlQuery,
       nonce,
+      expectedOrigins,
       transactionData,
     }: DCAPIAuthorizationRequestParams): Promise<string> {
+      if (expectedOrigins.length === 0) {
+        throw new Error("`expectedOrigins` must be a non-empty array");
+      }
       const encoded = encodeTxData(transactionData);
       const request: DCAPIAuthorizationRequest = {
         client_id: config.clientId,
         response_type: RESPONSE_TYPE,
         response_mode: "dc_api",
+        response_uri: config.callbackUri,
         nonce,
         dcql_query: dcqlQuery,
+        expected_origins: expectedOrigins,
         ...(encoded !== undefined && { transaction_data: [encoded] }),
       };
       return signRequestObject(config, { ...request });

--- a/packages/server/test/secured_request.test.mjs
+++ b/packages/server/test/secured_request.test.mjs
@@ -69,6 +69,7 @@ test("signedDcApiRequest returns a JAR with the expected header and claims", asy
     const jwt = await client.signedDcApiRequest({
       dcqlQuery: DCQL_QUERY_BASIC,
       nonce: "nonce-123",
+      expectedOrigins: ["https://verifier.example.com"],
     });
 
     assert.equal(calls.length, 1);
@@ -87,6 +88,24 @@ test("signedDcApiRequest returns a JAR with the expected header and claims", asy
     assert.equal(payload.response_mode, "dc_api");
     assert.equal(payload.nonce, "nonce-123");
     assert.deepEqual(payload.dcql_query, DCQL_QUERY_BASIC);
+    assert.equal(payload.response_uri, CALLBACK_URI);
+    assert.deepEqual(payload.expected_origins, [
+      "https://verifier.example.com",
+    ]);
+  });
+});
+
+test("signedDcApiRequest rejects an empty expectedOrigins array", async () => {
+  await withStubbedFetch(async () => {
+    const client = securedClient();
+    await assert.rejects(
+      client.signedDcApiRequest({
+        dcqlQuery: DCQL_QUERY_BASIC,
+        nonce: "nonce-123",
+        expectedOrigins: [],
+      }),
+      /`expectedOrigins` must be a non-empty array/,
+    );
   });
 });
 
@@ -211,7 +230,11 @@ test("signed methods require useSecuredAuthorizationRequest", async () => {
     privateKeyFactory: () => privateJwk,
   });
   await assert.rejects(
-    client.signedDcApiRequest({ dcqlQuery: DCQL_QUERY_BASIC, nonce: "n" }),
+    client.signedDcApiRequest({
+      dcqlQuery: DCQL_QUERY_BASIC,
+      nonce: "n",
+      expectedOrigins: ["https://verifier.example.com"],
+    }),
     /useSecuredAuthorizationRequest/,
   );
 });
@@ -224,7 +247,11 @@ test("signed methods require privateKeyFactory", async () => {
     useSecuredAuthorizationRequest: true,
   });
   await assert.rejects(
-    client.signedDcApiRequest({ dcqlQuery: DCQL_QUERY_BASIC, nonce: "n" }),
+    client.signedDcApiRequest({
+      dcqlQuery: DCQL_QUERY_BASIC,
+      nonce: "n",
+      expectedOrigins: ["https://verifier.example.com"],
+    }),
     /privateKeyFactory/,
   );
 });


### PR DESCRIPTION
## Summary

Adds two fields to the signed DC API request path in `packages/server`:

- **`response_uri`** — added to the `DCAPIAuthorizationRequest` payload, populated from the client's configured `callbackUri`.
- **`expected_origins`** — a new required `expectedOrigins` parameter on `signedDcApiRequest`, typed as a non-empty array (`[string, ...string[]]`) and validated at runtime (rejects an empty array). It is emitted as `expected_origins` in the signed request payload.

`signedDcApiRequest` is now `async` so the empty-array validation surfaces as a promise rejection, consistent with the other config-validation errors.

## Tests

- Existing `signedDcApiRequest` test updated to pass `expectedOrigins` and assert `response_uri` / `expected_origins` in the signed payload.
- New test covering rejection of an empty `expectedOrigins` array.
- Full suite passes; `yarn check-all` (format, lint, build, publint) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)