### PR TITLE
Release 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proof-vc-workspace",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Jeremie Charrier <jeremie.charrier@proof.com>",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-common",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proof.com/proof-vc-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A digital passport, verified once, usable everywhere.",
   "keywords": [
     "VC",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@owf/crypto": "^0.3.2",
     "@owf/identity-common": "^0.3.2",
-    "@proof.com/proof-vc-common": "0.4.0",
+    "@proof.com/proof-vc-common": "0.4.1",
     "@sd-jwt/core": "^0.20.0",
     "@sd-jwt/sd-jwt-vc": "^0.20.0",
     "jose": "^6.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,7 +203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@proof.com/proof-vc-common@npm:0.4.0, @proof.com/proof-vc-common@workspace:packages/common":
+"@proof.com/proof-vc-common@npm:0.4.1, @proof.com/proof-vc-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@proof.com/proof-vc-common@workspace:packages/common"
   dependencies:
@@ -218,7 +218,7 @@ __metadata:
   dependencies:
     "@owf/crypto": "npm:^0.3.2"
     "@owf/identity-common": "npm:^0.3.2"
-    "@proof.com/proof-vc-common": "npm:0.4.0"
+    "@proof.com/proof-vc-common": "npm:0.4.1"
     "@sd-jwt/core": "npm:^0.20.0"
     "@sd-jwt/sd-jwt-vc": "npm:^0.20.0"
     jose: "npm:^6.2.4"


### PR DESCRIPTION
Version bump to 0.4.1 (lockstep across both packages).

Includes [WALLET-184] — `response_uri` + `expected_origins` on the signed DC API request (#35).

- `packages/common` → 0.4.1
- `packages/server` → 0.4.1, pinned dependency on `@proof.com/proof-vc-common@0.4.1`
- `yarn.lock` refreshed

Once merged, a GitHub Release `v0.4.1` against the merged commit triggers `publish.yml` to publish both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)