### PR TITLE
[WALLET-185] Add login_hint and scope parameters to signedDcApiRequest

### DIFF
--- a/packages/common/src/internal.ts
+++ b/packages/common/src/internal.ts
@@ -44,16 +44,23 @@ export function resolveBaseUrl(environment: Environment): string {
   }
 }
 
+export function assertScopeOrDcql(params: {
+  scope: Scope | undefined;
+  dcqlQuery: DCQLQuery | undefined;
+}): void {
+  if ((params.scope === undefined) === (params.dcqlQuery === undefined)) {
+    throw new Error(
+      "authorization request requires exactly one of `scope` or `dcqlQuery`",
+    );
+  }
+}
+
 export function buildAuthorizationSearchParams(
   config: ClientConfig,
   params: AuthorizationRequestParams,
 ): URLSearchParams {
   const { scope, dcqlQuery, nonce, state, loginHint } = params;
-  if ((scope === undefined) === (dcqlQuery === undefined)) {
-    throw new Error(
-      "authorization request requires exactly one of `scope` or `dcqlQuery`",
-    );
-  }
+  assertScopeOrDcql({ scope, dcqlQuery });
   const responseMode = config.responseMode ?? DEFAULT_RESPONSE_MODE;
   return new URLSearchParams({
     client_id: config.clientId,

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -4,10 +4,11 @@ import {
   resolveBaseUrl,
   buildAuthorizationSearchParams,
   authorizeUrlFromSearchParams,
+  assertScopeOrDcql,
   type ClientConfig,
   type AuthorizationRequestParams,
 } from "@proof.com/proof-vc-common/internal";
-import type { DCQLQuery } from "@proof.com/proof-vc-common";
+import type { DCQLQuery, Scope } from "@proof.com/proof-vc-common";
 import type { JWK } from "jose";
 import {
   encodeTransactionData,
@@ -28,12 +29,10 @@ export type ServerAuthorizationRequestParams = AuthorizationRequestParams & {
   transactionData?: TransactionData | string;
 };
 
-export type DCAPIAuthorizationRequestParams = {
-  dcqlQuery: DCQLQuery;
-  nonce: string;
-  expectedOrigins: [string, ...string[]];
-  transactionData?: TransactionData | string;
-};
+export type DCAPIAuthorizationRequestParams =
+  ServerAuthorizationRequestParams & {
+    expectedOrigins: [string, ...string[]];
+  };
 
 export type DCAPIAuthorizationRequest = {
   client_id: string;
@@ -41,8 +40,11 @@ export type DCAPIAuthorizationRequest = {
   response_mode: "dc_api";
   response_uri: string;
   nonce: string;
-  dcql_query: DCQLQuery;
   expected_origins: [string, ...string[]];
+  scope?: Scope;
+  dcql_query?: DCQLQuery;
+  state?: string;
+  login_hint?: string;
   transaction_data?: string[];
 };
 
@@ -149,14 +151,18 @@ export function createClient(config: ServerClientConfig): ServerVCClient {
     },
 
     async signedDcApiRequest({
+      scope,
       dcqlQuery,
       nonce,
+      state,
+      loginHint,
       expectedOrigins,
       transactionData,
     }: DCAPIAuthorizationRequestParams): Promise<string> {
       if (expectedOrigins.length === 0) {
         throw new Error("`expectedOrigins` must be a non-empty array");
       }
+      assertScopeOrDcql({ scope, dcqlQuery });
       const encoded = encodeTxData(transactionData);
       const request: DCAPIAuthorizationRequest = {
         client_id: config.clientId,
@@ -164,8 +170,11 @@ export function createClient(config: ServerClientConfig): ServerVCClient {
         response_mode: "dc_api",
         response_uri: config.callbackUri,
         nonce,
-        dcql_query: dcqlQuery,
         expected_origins: expectedOrigins,
+        ...(scope !== undefined && { scope }),
+        ...(dcqlQuery !== undefined && { dcql_query: dcqlQuery }),
+        ...(state !== undefined && { state }),
+        ...(loginHint !== undefined && { login_hint: loginHint }),
         ...(encoded !== undefined && { transaction_data: [encoded] }),
       };
       return signRequestObject(config, { ...request });

--- a/packages/server/test/secured_request.test.mjs
+++ b/packages/server/test/secured_request.test.mjs
@@ -69,6 +69,8 @@ test("signedDcApiRequest returns a JAR with the expected header and claims", asy
     const jwt = await client.signedDcApiRequest({
       dcqlQuery: DCQL_QUERY_BASIC,
       nonce: "nonce-123",
+      state: "state-xyz",
+      loginHint: "user@example.com",
       expectedOrigins: ["https://verifier.example.com"],
     });
 
@@ -92,6 +94,40 @@ test("signedDcApiRequest returns a JAR with the expected header and claims", asy
     assert.deepEqual(payload.expected_origins, [
       "https://verifier.example.com",
     ]);
+    assert.equal(payload.state, "state-xyz");
+    assert.equal(payload.login_hint, "user@example.com");
+    assert.equal(payload.scope, undefined);
+  });
+});
+
+test("signedDcApiRequest supports a scope-based request", async () => {
+  await withStubbedFetch(async () => {
+    const client = securedClient();
+    const jwt = await client.signedDcApiRequest({
+      scope: "openid",
+      nonce: "nonce-123",
+      expectedOrigins: ["https://verifier.example.com"],
+    });
+
+    const { payload } = await jwtVerify(jwt, publicKey);
+    assert.equal(payload.scope, "openid");
+    assert.equal(payload.dcql_query, undefined);
+    assert.equal(payload.response_uri, CALLBACK_URI);
+  });
+});
+
+test("signedDcApiRequest rejects supplying both scope and dcqlQuery", async () => {
+  await withStubbedFetch(async () => {
+    const client = securedClient();
+    await assert.rejects(
+      client.signedDcApiRequest({
+        scope: "openid",
+        dcqlQuery: DCQL_QUERY_BASIC,
+        nonce: "nonce-123",
+        expectedOrigins: ["https://verifier.example.com"],
+      }),
+      /exactly one of `scope` or `dcqlQuery`/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Extends `signedDcApiRequest` (server DC API signed request) with optional `loginHint` and `scope`, and unifies its parameter type with `authorizationUrl`.

- `DCAPIAuthorizationRequestParams` is now `ServerAuthorizationRequestParams & { expectedOrigins }` — the same type `authorizationUrl` accepts, plus the required non-empty `expectedOrigins`. This brings in:
  - `scope` (optional) and `dcqlQuery` as a mutually-exclusive union — exactly one is required, matching `authorizationUrl` semantics; `dcql_query` is now optional in the payload.
  - `loginHint` (optional) → emitted as `login_hint`.
  - `state` (optional) → emitted as `state`, keeping the DC API payload consistent with the redirect flow.
- Deduplicated the `scope` XOR `dcqlQuery` validation into `assertScopeOrDcql` in `internal.ts`, now shared by `buildAuthorizationSearchParams` and the DC API path (runtime guard for JS callers; the union type already guards TS callers).

## Tests

- Extended the main DC API test with `state` / `loginHint` assertions.
- Added a scope-based request test and a both-`scope`-and-`dcqlQuery` rejection test.
- Full suite passes (19 server + 6 common); `yarn check-all` (format, lint, build, publint) is green; `common` verified runtime-pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)