### PR TITLE
Make expectedOrigins optional in signedDcApiRequest

### DIFF
--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -31,14 +31,14 @@ export type ServerAuthorizationRequestParams = AuthorizationRequestParams & {
 
 export type DCAPIAuthorizationRequestParams =
   ServerAuthorizationRequestParams & {
-    expectedOrigins: [string, ...string[]];
+    expectedOrigins?: [string, ...string[]];
   };
 
 export type DCAPIAuthorizationRequest = {
   client_id: string;
   response_type: typeof RESPONSE_TYPE;
   response_mode: "dc_api";
-  response_uri: string;
+  response_uri?: string;
   nonce: string;
   expected_origins: [string, ...string[]];
   scope?: Scope;
@@ -159,7 +159,7 @@ export function createClient(config: ServerClientConfig): ServerVCClient {
       expectedOrigins,
       transactionData,
     }: DCAPIAuthorizationRequestParams): Promise<string> {
-      if (expectedOrigins.length === 0) {
+      if (expectedOrigins !== undefined && expectedOrigins.length === 0) {
         throw new Error("`expectedOrigins` must be a non-empty array");
       }
       assertScopeOrDcql({ scope, dcqlQuery });
@@ -168,9 +168,11 @@ export function createClient(config: ServerClientConfig): ServerVCClient {
         client_id: config.clientId,
         response_type: RESPONSE_TYPE,
         response_mode: "dc_api",
-        response_uri: config.callbackUri,
         nonce,
-        expected_origins: expectedOrigins,
+        expected_origins: expectedOrigins ?? [""],
+        ...(expectedOrigins === undefined && {
+          response_uri: config.callbackUri,
+        }),
         ...(scope !== undefined && { scope }),
         ...(dcqlQuery !== undefined && { dcql_query: dcqlQuery }),
         ...(state !== undefined && { state }),

--- a/packages/server/test/secured_request.test.mjs
+++ b/packages/server/test/secured_request.test.mjs
@@ -90,13 +90,27 @@ test("signedDcApiRequest returns a JAR with the expected header and claims", asy
     assert.equal(payload.response_mode, "dc_api");
     assert.equal(payload.nonce, "nonce-123");
     assert.deepEqual(payload.dcql_query, DCQL_QUERY_BASIC);
-    assert.equal(payload.response_uri, CALLBACK_URI);
     assert.deepEqual(payload.expected_origins, [
       "https://verifier.example.com",
     ]);
+    assert.equal(payload.response_uri, undefined);
     assert.equal(payload.state, "state-xyz");
     assert.equal(payload.login_hint, "user@example.com");
     assert.equal(payload.scope, undefined);
+  });
+});
+
+test("signedDcApiRequest omits expectedOrigins and includes response_uri", async () => {
+  await withStubbedFetch(async () => {
+    const client = securedClient();
+    const jwt = await client.signedDcApiRequest({
+      dcqlQuery: DCQL_QUERY_BASIC,
+      nonce: "nonce-123",
+    });
+
+    const { payload } = await jwtVerify(jwt, publicKey);
+    assert.equal(payload.response_uri, CALLBACK_URI);
+    assert.deepEqual(payload.expected_origins, [""]);
   });
 });
 
@@ -112,7 +126,7 @@ test("signedDcApiRequest supports a scope-based request", async () => {
     const { payload } = await jwtVerify(jwt, publicKey);
     assert.equal(payload.scope, "openid");
     assert.equal(payload.dcql_query, undefined);
-    assert.equal(payload.response_uri, CALLBACK_URI);
+    assert.equal(payload.response_uri, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

Makes `expectedOrigins` optional on `signedDcApiRequest` and couples it with `response_uri`:

- `expectedOrigins` is now optional (`expectedOrigins?: [string, ...string[]]`); `response_uri` is now optional in the `DCAPIAuthorizationRequest` payload.
- **When `expectedOrigins` is passed**: `expected_origins` is set to it and `response_uri` is **omitted**.
- **When `expectedOrigins` is not passed**: `response_uri` is included (= configured `callbackUri`) and `expected_origins` defaults to `[""]`.
- The non-empty guard now only fires when `expectedOrigins` is explicitly passed as an empty array (JS-caller safety).

## Tests

- Updated the two existing DC API tests to assert `response_uri` is omitted when origins are passed.
- Added a test for the not-passed case: asserts `response_uri` equals the callback URI and `expected_origins` is `[""]`.
- Full suite passes (20 server + 6 common); `yarn check-all` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)